### PR TITLE
tests/inet_socket: fix output of planned tests count

### DIFF
--- a/tests/inet_socket/test
+++ b/tests/inet_socket/test
@@ -3,7 +3,7 @@ use Test::More;
 
 BEGIN {
     # check if ip xfrm supports ctx parameter
-    if (system("ip xfrm policy help 2>&1 | grep ctx") != 0) {
+    if (system("ip xfrm policy help 2>&1 | grep -q ctx") != 0) {
         plan skip_all => "ctx not supported in ip xfrm policy";
     } else {
         plan tests => 20;


### PR DESCRIPTION
Stephen reported that commit 1ae80460699819ce0e7360c315a3803ee271e11f
has introduced a small problem to test output. While the test is
progressing as you watch output of "make test", you'll see that
it displays its progress as N/? (e.g. 17/?) while executing the
inet_socket tests, as if it does not know the final count.

The reason appears to be that perl implementation does not expect any
output before you define a "plan", but commit above introduced
system() call, which now generates some output. Consequence of that
is that report function (TAP::Formatter::Console::Session) is called
before TAP::Parser initialized "plan", and it creates wrong format
string which it then keeps for the duration of test.

Reported-by: Stephen Smalley <sds@tycho.nsa.gov>
Signed-off-by: Jan Stancek <jstancek@redhat.com>