### PR TITLE
Testsuite was failing on RHEL7

### DIFF
--- a/policy/test_overlayfs.te
+++ b/policy/test_overlayfs.te
@@ -39,6 +39,7 @@ allow test_overlay_mounter_t self:capability { sys_admin dac_override dac_read_s
 
 unconfined_runs_test(test_overlay_mounter_t)
 
+kernel_read_system_state(test_overlay_mounter_t)
 kernel_read_proc_symlinks(test_overlay_mounter_t)
 kernel_request_load_module(test_overlay_mounter_t)
 kernel_search_proc(test_overlay_mounter_t)
@@ -117,7 +118,7 @@ corecmd_shell_entry_type(test_overlay_client_t)
 corecmd_bin_entry_type(test_overlay_client_t)
 corecmd_exec_bin(test_overlay_client_t)
 
-kernel_search_proc(test_overlay_client_t)
+kernel_read_system_state(test_overlay_client_t)
 kernel_read_proc_symlinks(test_overlay_client_t)
 
 userdom_read_inherited_user_tmp_files(test_overlay_client_t)

--- a/tests/overlay/test
+++ b/tests/overlay/test
@@ -17,8 +17,8 @@ sub cleanup() {
 
 sub getfilecon {
         my ($filename) = @_;
-	$output = `ls -dZ $filename | cut -f1 -d' '`;
-	$output =~ s/\n//g;
+	$output = `getfattr -d -n security.selinux $filename --only-values 2> /dev/null`;
+	chop($output);
 	return $output;
 }
 


### PR DESCRIPTION
ls -Z on current coreutils is different then on RHEL7, so this is causing
getfilecon tests to fail.  Changed to use getfattr.

Also perl does not like ($output eq "unconfined...")
Changing to ($output == "unconfined...")

Makes it work on RHEL and Fedora