### PR TITLE
skip cap_userns tests on distros that disable CLONE_NEWUSER

### DIFF
--- a/tests/cap_userns/test
+++ b/tests/cap_userns/test
@@ -1,14 +1,20 @@
 #!/usr/bin/perl
 
-use Test;
-BEGIN { plan tests => 2}
+use Test::More;
+BEGIN {
+	$basedir = $0;  $basedir =~ s|(.*)/[^/]*|$1|;
 
-$basedir = $0;  $basedir =~ s|(.*)/[^/]*|$1|;
+	if (system("$basedir/userns_child_exec -t -U > /dev/null 2>&1") == 0) {
+		plan tests => 2
+	} else {
+		plan skip_all => "CLONE_NEWUSER not supported";
+	}
+}
 
 # Verify that test_cap_userns_t can mount proc within its own mount namespace.
 
 $result = system ("runcon -t test_cap_userns_t -- $basedir/userns_child_exec -p -m -U -M '0 0 1' -G '0 0 1' -- true 2>&1");
-ok($result, 0);
+ok($result eq 0);
 
 # Verify that test_no_cap_userns_t cannot mount proc within its own mount namespace.
 


### PR DESCRIPTION
RHEL7 [1] (and possibly other distros) disable CLONE_NEWUSER by default. This series adds a check to see if simple clone(CLONE_NEWUSER) works, if not cap_userns tests are skipped.

We didn't see this until RHEL7.4, because of following Makefile check, that skipped the test:
```
ifeq ($(shell grep -q cap_userns $(POLDEV)/include/support/all_perms.spt && echo true),true)
SUBDIRS += cap_userns
endif
```
7.4 policy update now makes condition above true.

[1] http://rhelblog.redhat.com/2015/07/07/whats-next-for-containers-user-namespaces/ (comment 2)