### PR TITLE
selinux-testsuite: work around missing garbage collection on ipsec-flush

### DIFF
--- a/tests/inet_socket/ipsec-flush
+++ b/tests/inet_socket/ipsec-flush
@@ -1,5 +1,6 @@
 #!/bin/sh
 echo 1 > /proc/sys/net/ipv4/conf/lo/disable_xfrm
 echo 1 > /proc/sys/net/ipv4/conf/lo/disable_policy
+ip xfrm policy deleteall
 ip xfrm policy flush
 ip xfrm state flush


### PR DESCRIPTION
ipsec-load/ipsec-flush leaves older kernels in state where some
communication over loopback (e.g. SCTP) generates unexpected AVCs.

This can be reproduced up to 4.10 by running selinux-testsuite and
then sendto02 from LTP [1], which triggers:
  avc:  denied  { recv } for  pid=7995 comm="sendto02" saddr=127.0.0.1
  daddr=127.0.0.1 netif=lo scontext=system_u:system_r:kernel_t:s0
  tcontext=system_u:object_r:unlabeled_t:s0 tclass=peer

At minimum you need to run one ipsec test, for example:
```
  # cd selinux-testsuite
  # make -C policy load
  # cd tests/inet_socket/
  # make
  # chcon -R -t test_file_t .
  # ./ipsec-load
  # runcon -t test_inet_server_t ./server stream 65535 &
  # server=$!
  # sleep 1
  # runcon -t test_inet_client_t ./client stream 127.0.0.1 65535
  # kill $server
  # ./ipsec-flush
  # cd ../..
  # make -C policy unload
  # /root/ltp/sendto02
  # tail /var/log/audit/audit.log
```

4.11 has fixed this by doing garbage collection on policy flush:
```
  commit 35db0691218959f05efbe26fd623ee67581ebff6
  Author: Xin Long <lucien.xin@gmail.com>
  Date:   Mon Apr 24 15:33:39 2017 +0800

    xfrm: do the garbage collection after flushing policy

    Now xfrm garbage collection can be triggered by 'ip xfrm policy del'.
    These is no reason not to do it after flushing policies, especially
    considering that 'garbage collection deferred' is only triggered
    when it reaches gc_thresh.

    It's no good that the policy is gone but the xdst still hold there.
    The worse thing is that xdst->route/orig_dst is also hold and can
    not be released even if the orig_dst is already expired.

    This patch is to do the garbage collection if there is any policy
    removed in xfrm_policy_flush.

    Signed-off-by: Xin Long <lucien.xin@gmail.com>
    Signed-off-by: Steffen Klassert <steffen.klassert@secunet.com>
```

This patch is a workaround for kernels < 4.11, that do garbage collect
on policy delete.

[1] https://github.com/linux-test-project/ltp/blob/master/testcases/kernel/syscalls/sendto/sendto02.c

Signed-off-by: Jan Stancek <jstancek@redhat.com>