### PR TITLE
selinux-testsuite: avoid errors on older RHEL versions

### DIFF
--- a/policy/Makefile
+++ b/policy/Makefile
@@ -65,6 +65,10 @@ ifeq (x$(DISTRO),$(filter x$(DISTRO),xRHEL4 xRHEL5 xRHEL6))
 TARGETS:=$(filter-out test_overlayfs.te test_mqueue.te, $(TARGETS))
 endif
 
+ifeq (x$(DISTRO),$(filter x$(DISTRO), xRHEL6))
+TARGETS:=$(filter-out test_ibpkey.te, $(TARGETS))
+endif
+
 ifeq (x$(DISTRO),$(filter x$(DISTRO),xRHEL4 xRHEL5))
 	BUILD_TARGET := build_rhel
 	LOAD_TARGET := load_rhel

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,11 +36,11 @@ ifeq ($(DISTRO),RHEL4)
 endif
 
 ifeq ($(DISTRO),RHEL5)
-    SUBDIRS:=$(filter-out bounds inet_socket mmap nnp_nosuid overlay unix_socket, $(SUBDIRS))
+    SUBDIRS:=$(filter-out bounds inet_socket mmap nnp_nosuid overlay unix_socket atsecure mac_admin, $(SUBDIRS))
 endif
 
 ifeq ($(DISTRO),RHEL6)
-    SUBDIRS:=$(filter-out nnp_nosuid overlay, $(SUBDIRS))
+    SUBDIRS:=$(filter-out nnp_nosuid overlay atsecure, $(SUBDIRS))
 endif
 
 ifeq ($(DISTRO),RHEL7)


### PR DESCRIPTION
- CAP_MAC_ADMIN is not supported on RHEL 5 kernels, causing unexpected
  test failures
- newer glibc with auxv.h is needed for AT_SECURE testing (build fails
  on RHEL 5 and RHEL 6)
- 'dev_rw_infiniband_dev' is not defined in RHEL 6 policy.

Exlude these tests from running on unsupported versions.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>