### PR TITLE
overlay: Remove bad entry point test for context mounts

### DIFF
--- a/policy/test_overlayfs.te
+++ b/policy/test_overlayfs.te
@@ -66,6 +66,7 @@ selinux_getattr_fs(test_overlay_mounter_t)
 # Needs to be able to relabelto/from when it does the mount context=
 #
 allow test_overlay_mounter_t test_overlay_files_ro_t:file mounton;
+allow test_overlay_mounter_t test_overlay_files_ro_t:filesystem { mount relabelfrom relabelto };
 allow test_overlay_mounter_t test_overlay_files_rwx_t:{dir file} mounton;
 allow test_overlay_mounter_t test_overlay_files_rwx_t:filesystem { mount relabelfrom relabelto };
 can_exec(test_overlay_mounter_t, test_overlay_files_ro_t)

--- a/tests/overlay/test
+++ b/tests/overlay/test
@@ -941,9 +941,8 @@ sub context_test {
     test_81_ctx();
     test_82();
     print "=====================================================\n";
-    print "Bad Entrypoint tests.\n";
+    print "Good Entrypoint test.\n";
     print "=====================================================\n";
-    test_90_1();
     test_90_2();
     print "=====================================================\n";
     print "xattr tests.\n";
@@ -956,9 +955,34 @@ sub context_test {
     test_93_1();
 }
 
+sub context_rot_t_test {
+
+    cleanup();
+    $context = "unconfined_u:object_r:test_overlay_files_ro_t:s0:c10,c20";
+    print "\n\n=====================================================\n";
+    print "Testing mounting overlayfs with context switch\n";
+    print "context=$context\n";
+    print "=====================================================\n\n";
+
+    if ( system("$basedir/setup-overlay $basedir '$context'") == 0 ) {
+        print "Mounted overlay with context=$context.\n";
+    }
+    else {
+        print "setup-overlay failed. Cleaning up.\n";
+        cleanup();
+        exit;
+    }
+    print "=====================================================\n";
+    print "Bad Entrypoint test.\n";
+    print "=====================================================\n";
+    test_90_1();
+}
+
 nocontext_test();
 
 context_test();
+
+context_rot_t_test();
 
 cleanup();
 


### PR DESCRIPTION
Current bad entry point test for context mounts does not make much sense.
During the test we are mounting overlay with context=...rwx_t. And that
means process will see this label on overlay inode and that should allow
entry.

We are expecting entry to fail. But, given process is seeing rwx_t, and
as per policy entrypoint into that is allowed. So this test case in
current form does not make much sense for context mounts.

Why it works currently, because selinux is actually checking the label
of lower file (ro_t) instead of label of overlay inode (rwx_t) and that's
why entrypoint fails. But this is wrong expectations.

So get rid of this test. New overlay patches are proposed where it will
soon start failing.
 
Signed-off-by: Vivek Goyal <vgoyal@redhat.com>