### PR TITLE
BUG: allow mounter getattr access to noaccess_t files

### DIFF
--- a/policy/test_overlayfs.te
+++ b/policy/test_overlayfs.te
@@ -71,6 +71,12 @@ allow test_overlay_mounter_t test_overlay_files_rwx_t:{dir file} mounton;
 allow test_overlay_mounter_t test_overlay_files_rwx_t:filesystem { mount relabelfrom relabelto };
 can_exec(test_overlay_mounter_t, test_overlay_files_ro_t)
 
+# Mount should be able to do getattr on noaccess files. Overlayfs performs
+# getattr on underlying files during dentry lookup in the context of mounter
+# of filesystem. If mounter does not have getattr, unlink of a noaccess
+# file fails with context mount.
+allow test_overlay_mounter_t test_overlay_files_noaccess_t:file getattr;
+
 #
 # Mounter should be allowed to search/read r/o directories and files
 #

--- a/tests/overlay/test
+++ b/tests/overlay/test
@@ -7,7 +7,7 @@ BEGIN {
         plan skip_all => "overlayfs not supported with SELinux in this kernel";
     }
     else {
-        plan tests => 121;
+        plan tests => 118;
     }
 }
 
@@ -881,7 +881,6 @@ sub context_test {
     print "=====================================================\n";
     print "chmod tests.\n";
     print "=====================================================\n";
-    test_20();
     test_21();
     test_22();
     test_23_ctx();
@@ -891,7 +890,6 @@ sub context_test {
     print "=====================================================\n";
     print "getcon tests.\n";
     print "=====================================================\n";
-    test_30();
     test_31();
     test_32();
 
@@ -913,7 +911,6 @@ sub context_test {
     print "=====================================================\n";
     test_50();
     test_51();
-    test_52();
 
     print "=====================================================\n";
     print "access tests.\n";


### PR DESCRIPTION
Overlay filesystem recently added support for metadata only copy up feature.
This feature stores a xattr named overlay.metacopy if a file is metadata
only and data is in some file in lower layer.

This means during lookup, metacopy xattr is searched for to determine if
a dentry is metadata only dentry or not. If it is, then search continues
in lower layers to find actual data dentry.

All this happens with the creds of mounter and this means mounter atleast
needs to have getattr permission on underlying file, otherwise lookup
will fail.

With this change in overlayfs, one test (test_72_ctx) broke. We are trying
to unlink a file and it failed because dentry lookup failed.

Before metacopy we had "origin" xattr which is looked up in dentry lookup
path as well. We never ran into that issue because it happens only if
there is a file present in upper directory. As test_72_ctx worked only
with files in lower, it worked and did not break with introduction of
origin xattr.

To fix this test case, allow mounter "getattr" permission on noaccess_file_t.

This makes 3 other tests fail which test that getattr on noaccess_file_t
should fail. I am disabling these tests as these are not valid anymore
with this change.

test_20(), test_30() and test_52() now do not make sense for context mounts.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>