### PR TITLE
BUG: fix unlink tests

### DIFF
--- a/tests/overlay/setup-overlay
+++ b/tests/overlay/setup-overlay
@@ -13,6 +13,7 @@ setup () {
     echo read > $BASEDIR/lower/readfile
     echo write > $BASEDIR/lower/writefile
     echo noaccess > $BASEDIR/lower/noaccessfile
+    echo client_nounlink > $BASEDIR/lower/client_nounlinkfile
     echo mounter > $BASEDIR/lower/mounterfile
     echo transition > $BASEDIR/lower/transition
     cp $BASEDIR/badentrypoint $BASEDIR/lower/

--- a/tests/overlay/test
+++ b/tests/overlay/test
@@ -7,7 +7,7 @@ BEGIN {
         plan skip_all => "overlayfs not supported with SELinux in this kernel";
     }
     else {
-        plan tests => 121;
+        plan tests => 119;
     }
 }
 
@@ -549,18 +549,18 @@ sub test_67 {
 }
 
 sub test_70 {
-    print "Check unlink access on readfile, should fail.\n";
+    print "Check unlink access on client_nounlinkfile, should fail.\n";
     $result = system(
-"runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/readfile 2>/dev/null"
+"runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/client_nounlinkfile 2>/dev/null"
     );
     ok($result);
     return;
 }
 
 sub test_70_ctx {
-    print "Check unlink access on readfile, should succeed.\n";
+    print "Check unlink access on client_nounlinkfile, should succeed.\n";
     $result = system(
-"runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/readfile >/dev/null"
+"runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/client_nounlinkfile >/dev/null"
     );
     ok( $result == 0 );
     return;
@@ -570,24 +570,6 @@ sub test_71 {
     print "Check unlink access on writefile, should succeed.\n";
     $result = system(
 "runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/writefile >/dev/null"
-    );
-    ok( $result == 0 );
-    return;
-}
-
-sub test_72 {
-    print "Check unlink access on noaccessfile, should fail.\n";
-    $result = system(
-"runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/noaccessfile 2>/dev/null"
-    );
-    ok($result);
-    return;
-}
-
-sub test_72_ctx {
-    print "Check unlink access on noaccessfile, should succeed.\n";
-    $result = system(
-"runcon -t test_overlay_client_t -l s0:c10,c20 unlink $basedir/container1/merged/noaccessfile 2>/dev/null"
     );
     ok( $result == 0 );
     return;
@@ -813,7 +795,6 @@ sub nocontext_test {
     print "=====================================================\n";
     test_70();
     test_71();
-    test_72();
     test_80();
     test_81();
     test_82();
@@ -932,7 +913,6 @@ sub context_test {
     print "=====================================================\n";
     test_70_ctx();
     test_71();
-    test_72_ctx();
 
     print "=====================================================\n";
     print "Mounter tests.\n";


### PR DESCRIPTION
test_70() tries unlink on readfile. It is label ro_t. It is only implied
that client can't do unlink on this file. A better method might be to
drop a file with name client_nounlinkfile (with label ro_t). Now file name
makes it plenty clear that label this file in such a way so that client
can not unlink it. As of now ro_t meets that requirement. Later one can
come up with a new label if need be.

Similarly modify test_70_ctx() to unlink client_nounlinkfile. It makes it
plenty clear that this file can't be unlinked by client. But if a context
mount is done with label rwx_t, then that label overrides real label and
now file can be unlinked.

Get rid of test_72() and test_72_ctx(). These tests don't make much sense
in current form for multiple reasons.

- noaccessfile does not have unlink permission for client. So it is basically
  testing what test_70() is testing.

- test_72_ctx() is very similar to test_70_ctx(). Only difference is that
  mounter can not do getattr() on noaccessfile. So this test passes till
  4.18 kernel but fails 4.19-rc1 onwards as ovl_lookup() checks for metacopy
  xattr and mounter needs getattr. IOW, it seems orthogonal to testing
  unlink capability of either mounter or client. And test_70_ctx() should
  be good enough if context mounts override the real file label or not. 

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>