### PR TITLE
selinux-testsuite: Add missing tmpfs_t map permission to ipcdomain

### DIFF
--- a/policy/test_ipc.te
+++ b/policy/test_ipc.te
@@ -70,8 +70,9 @@ allow test_ipc_base_t test_ipc_base_t:capability ipc_lock;
 # Needed for msgctl IPC_SET test
 allow test_ipc_associate_t test_ipc_associate_t:capability sys_resource;
 
-# Access tmpfs/shm file systems.
+# Access and map tmpfs/shm file systems.
 fs_rw_tmpfs_files(ipcdomain)
+allow_map(ipcdomain, tmpfs_t, file)
 
 # Allow all of these domains to be entered from user domains.
 # via a shell script in the test directory or by another program.


### PR DESCRIPTION
The shmat test in tests/shm calls shmat(2), which needs the 'map'
permission on tmpfs_t files. However, the test policy does not contain a
rule that would allow the 'test_ipc_base_t' domain to map files labeled
'tmpfs_t'.

On older kernels, the 'map' permission of the 'file' class was not
supported and thus the failure did not occur.

This patch adds the necessary rule to the test policy to fix the
problem.

Example AVC generated by the failing test:
```
type=PROCTITLE msg=audit(09/24/18 10:03:49.389:500) : proctitle=shm/shmat
type=SYSCALL msg=audit(09/24/18 10:03:49.389:500) : arch=x86_64 syscall=shmat success=no exit=EACCES(Permission denied) a0=0x10000 a1=0x0 a2=0x0 a3=0x7fff9a546420 items=0 ppid=13704 pid=13712 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts1 ses=2 comm=shmat exe=[...]/tests/shm/shmat subj=unconfined_u:unconfined_r:test_ipc_base_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(09/24/18 10:03:49.389:500) : avc:  denied  { map } for  pid=13712 comm=shmat path=/SYSV00008888 (deleted) dev="tmpfs" ino=65536 scontext=unconfined_u:unconfined_r:test_ipc_base_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:tmpfs_t:s0 tclass=file permissive=0
```

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>