### PR TITLE
RFE: add submount test

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ the tests:
 	tests/infiniband_pkey/ibpkey_test.conf
 	tests/infiniband_endport/ibendport_test.conf
 
+#### NFS server and client support
+
+The NFS automount test (tests/submount) requires NFS server and client support
+in the kernel.  In addition, it requires the NFS utility programs and a running
+NFS daemon.  On Fedora/RHEL you need the following package (other distributions
+should have a similar package):
+
+* nfs-utils _(to setup the NFS server and export directory trees)_
+
+On a modern Fedora system you can install it with the following command:
+
+	# dnf install nfs-utils
+
+The process to start the NFS server service varies across distributions, but
+usually you can start it by running:
+
+	# service nfs-server start
+	(or)
+	# service nfs start
+	(or)
+	# systemctl start nfs-server
+	(or)
+	# systemctl start nfs
+
 ## Running the Tests
 
 Create a shell with the `unconfined_r` or `sysadm_r` role and the Linux

--- a/defconfig
+++ b/defconfig
@@ -67,3 +67,14 @@ CONFIG_ANDROID_BINDERFS=y
 # They are not required for SELinux operation itself.
 CONFIG_BPF=y
 CONFIG_BPF_SYSCALL=y
+
+# NFS server and client.
+# This is enabled for testing NFS automount in tests/submount.
+# It is not required for SELinux operation itself.
+CONFIG_NETWORK_FILESYSTEMS=y
+CONFIG_FILE_LOCKING=y
+CONFIG_MULTIUSER=y
+CONFIG_NFSD=m
+CONFIG_NFSD_V3=y
+CONFIG_NFS_FS=m
+CONFIG_NFS_V3=m

--- a/policy/Makefile
+++ b/policy/Makefile
@@ -24,7 +24,7 @@ TARGETS = \
 	test_task_getsid.te test_task_setpgid.te test_task_setsched.te \
 	test_transition.te test_unix_socket.te \
 	test_mmap.te test_overlayfs.te test_mqueue.te \
-	test_ibpkey.te test_atsecure.te test_cgroupfs.te
+	test_ibpkey.te test_atsecure.te test_cgroupfs.te test_submount.te
 
 ifeq ($(shell [ $(POL_VERS) -ge 24 ] && echo true),true)
 TARGETS += test_bounds.te test_nnp_nosuid.te

--- a/policy/test_submount.te
+++ b/policy/test_submount.te
@@ -1,0 +1,31 @@
+#################################
+#
+# Policy for testing NFS crosmnt
+#
+
+# A domain that can access NFS files/directories
+type test_readnfs_t;
+domain_type(test_readnfs_t)
+unconfined_runs_test(test_readnfs_t)
+domain_obj_id_change_exemption(test_readnfs_t)
+typeattribute test_readnfs_t testdomain;
+
+# Allow execution of helper programs
+corecmd_exec_bin(test_readnfs_t)
+domain_exec_all_entry_files(test_readnfs_t)
+libs_use_ld_so(test_readnfs_t)
+libs_use_shared_libs(test_readnfs_t)
+libs_exec_ld_so(test_readnfs_t)
+libs_exec_lib_files(test_readnfs_t)
+
+# Allow this domain to be entered from sysadm domain
+miscfiles_domain_entry_test_files(test_readnfs_t)
+userdom_sysadm_entry_spec_domtrans_to(test_readnfs_t)
+corecmd_bin_entry_type(test_readnfs_t)
+sysadm_bin_spec_domtrans_to(test_readnfs_t)
+
+# Allow the domain to search home dirs so that ls works
+userdom_search_generic_user_home_dirs(test_readnfs_t)
+
+# Allow the domain to read NFS mounted files/directories
+fs_read_nfs_files(test_readnfs_t)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,8 @@ SUBDIRS:= domain_trans entrypoint execshare exectrace execute_no_trans \
 	task_setnice task_setscheduler task_getscheduler task_getsid \
 	task_getpgid task_setpgid file ioctl capable_file capable_net \
 	capable_sys dyntrans dyntrace bounds nnp_nosuid mmap unix_socket \
-	inet_socket overlay checkreqprot mqueue mac_admin atsecure
+	inet_socket overlay checkreqprot mqueue mac_admin atsecure \
+	submount
 
 ifeq ($(shell grep -q cap_userns $(POLDEV)/include/support/all_perms.spt && echo true),true)
 ifneq ($(shell ./kvercmp $$(uname -r) 4.7),-1)

--- a/tests/submount/Makefile
+++ b/tests/submount/Makefile
@@ -1,0 +1,2 @@
+all:
+clean:

--- a/tests/submount/test
+++ b/tests/submount/test
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0
+#
+# This test checks that NFS automounts do not trigger
+# unwanted SELinux checks for mount permission
+#
+# Author:  Ondrej Mosnacek <omosnace@redhat.com>
+# Based on code by:  Martin Frodl <mfrodl@redhat.com>
+# Copyright (c) 2018 Red Hat, Inc.
+#
+
+use Test::More;
+use File::Spec;
+
+my ( $basedir, $result );
+
+BEGIN {
+    $basedir = File::Spec->rel2abs($0);
+    $basedir =~ s|(.*)/[^/]*|$1|;
+
+    system "rm -rf $basedir/nfs_export 2>&1";
+    system "rm -rf $basedir/nfs_import 2>&1";
+
+    system "mkdir $basedir/nfs_export";
+    system "mkdir $basedir/nfs_import";
+
+    # Try exporting and mounting NFS.
+    $result =
+      system "exportfs -o ro,crossmnt,sync 127.0.0.1:$basedir/nfs_export 2>&1";
+    $result += system "mount -t nfs -o ro,timeo=5,retry=0,retrans=1 "
+      . "127.0.0.1:$basedir/nfs_export $basedir/nfs_import 2>&1";
+
+    # Cleanup.
+    system "umount $basedir/nfs_import 2>&1";
+    system "exportfs -u 127.0.0.1:$basedir/nfs_export 2>&1";
+
+    # If basic NFS workflow failed, then skip the test.
+    if ( $result eq 0 ) {
+        plan tests => 2;
+    }
+    else {
+        system "rm -rf $basedir/nfs_export 2>&1";
+        system "rm -rf $basedir/nfs_import 2>&1";
+        plan skip_all => "Unable to use NFS server/client";
+    }
+}
+
+# Create an EXT2 image to mount as submount (NFS needs a fs with UUID).
+system
+  "dd if=/dev/zero of=$basedir/nfs_export/image.ext2 bs=5M count=1 status=none";
+system "mkfs.ext2 -q -F $basedir/nfs_export/image.ext2";
+
+# Create the submount dir and mount the EXT2 image on it.
+system "mkdir $basedir/nfs_export/submount";
+system "mount -t ext2 -o loop "
+  . "$basedir/nfs_export/image.ext2 $basedir/nfs_export/submount";
+system "touch $basedir/nfs_export/submount/file";
+
+system "chcon -R -t test_file_t $basedir/nfs_export";
+
+# Export the directory.
+system "exportfs -o ro,crossmnt,sync 127.0.0.1:$basedir/nfs_export";
+
+# Mount the NFS export.
+system "mount -t nfs -o ro 127.0.0.1:$basedir/nfs_export $basedir/nfs_import";
+
+# Sanity check if we can access the mounted filesystem.
+$result =
+  system "runcon -t test_readnfs_t -- ls $basedir/nfs_import >/dev/null";
+ok( $result eq 0 );
+
+# Check that we can access the submounted filesystem.
+$result = system "runcon -t test_readnfs_t -- "
+  . "cat $basedir/nfs_import/submount/file >/dev/null";
+ok( $result eq 0 );
+
+# Cleanup.
+system "umount $basedir/nfs_import 2>&1";
+system "exportfs -u 127.0.0.1:$basedir/nfs_export 2>&1";
+while ( system("umount $basedir/nfs_export/submount 2>&1") ne 0 ) {
+    select( undef, undef, undef, 1 );
+}
+system "rm -rf $basedir/nfs_export 2>&1";
+system "rm -rf $basedir/nfs_import 2>&1";


### PR DESCRIPTION
Add a test that verifies that SELinux permissions are not checked when
mounting submounts. The test sets up a simple local NFS export on a
directory which has another filesystem mounted on its subdirectory.
Since the export is set up with the crossmnt option enabled, any client
mount will try to transparently mount any subdirectory that has a
filesystem mounted on it on the server, triggering an internal mount.
The test tries to access the automounted part of this export via a
client mount without having a permission to mount filesystems, expecting
it to succeed.

At the time of writing, this test fails on all upstream kernels. To
pass, it requires the following kernel patch to be applied:

https://lore.kernel.org/selinux/20181116131202.26513-1-omosnace@redhat.com/T/

The test first checks whether it is able to export and mount directories
via NFS and skips the actual tests if e.g. NFS daemon is not running.
This means that the testsuite can still be run without having the NFS
server installed and running.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>