### PR TITLE
BUG: fix use of uninitialized variable in sctp test

### DIFF
--- a/tests/sctp/sctp_server.c
+++ b/tests/sctp/sctp_server.c
@@ -22,7 +22,7 @@ static void usage(char *progname)
 
 int main(int argc, char **argv)
 {
-	int opt, sock, newsock, result, flags, if_index = 0, on = 1;
+	int opt, sock, newsock, result, if_index = 0, on = 1;
 	socklen_t sinlen, opt_len;
 	struct sockaddr_storage sin;
 	struct addrinfo hints, *res;
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
 
 			result = sctp_recvmsg(sock, msglabel, sizeof(msglabel),
 					      (struct sockaddr *)&sin, &sinlen,
-					      &sinfo, &flags);
+					      &sinfo, NULL);
 			if (result < 0) {
 				perror("Server sctp_recvmsg");
 				close(sock);


### PR DESCRIPTION
The sctp_recvmsg() function passes the value of the *msg_flags argument
to the recvmsg(2) system call [1], but in sctp_server.c the flags
variable is never initialized. This lead to sctp_recvmsg() sometimes
returning -EAGAIN, because the garbage flags sometimes marked the
recvmsg(2) call as non-blocking.

Since the function allows to pass NULL in msg_flags and we do not care
about the returned flags, let's just pass NULL and remove the flags
variable entirely.

[1] https://github.com/sctp/lksctp-tools/blob/356de6906c5b6d563f2d0568e86e3875ad482c66/src/lib/recvmsg.c#L77

Fixes: c38b57ffdac4 ("selinux-testsuite: Add SCTP test support")
Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>