### PR TITLE
BUG: fix typo in test_ipc.te

### DIFF
--- a/policy/redhat/5/test_ipc.te
+++ b/policy/redhat/5/test_ipc.te
@@ -77,7 +77,6 @@ corecmd_bin_entry_type(ipcdomain)
 userdom_sysadm_bin_spec_domtrans_to(ipcdomain)
 
 allow test_ipc_base_t self:sem create_sem_perms;
-allow test_ipc_base_t self:shm create_sem_perms;
-allow test_ipc_base_t self:shm lock;
+allow test_ipc_base_t self:shm create_shm_perms;
 # ipcrm needs this... 
 userdom_search_generic_user_home_dirs(test_ipc_base_t)

--- a/policy/test_ipc.te
+++ b/policy/test_ipc.te
@@ -81,7 +81,6 @@ corecmd_bin_entry_type(ipcdomain)
 sysadm_bin_spec_domtrans_to(ipcdomain)
 
 allow test_ipc_base_t self:sem create_sem_perms;
-allow test_ipc_base_t self:shm create_sem_perms;
-allow test_ipc_base_t self:shm lock;
+allow test_ipc_base_t self:shm create_shm_perms;
 # ipcrm needs this... 
 userdom_search_generic_user_home_dirs(test_ipc_base_t)


### PR DESCRIPTION
There is a subtle copy-paste mistake in test_ipc.te (shm vs. sem). This
is probably benign, since both permission sets are almost the same, but
let's make it also semantically correct.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>