### PR TITLE
RFE: add minimal test for cgroupfs label inheritance

### DIFF
--- a/policy/Makefile
+++ b/policy/Makefile
@@ -25,7 +25,7 @@ TARGETS = \
 	test_task_getsid.te test_task_setpgid.te test_task_setsched.te \
 	test_transition.te test_inet_socket.te test_unix_socket.te \
 	test_mmap.te test_overlayfs.te test_mqueue.te test_mac_admin.te \
-	test_ibpkey.te test_atsecure.te
+	test_ibpkey.te test_atsecure.te test_cgroupfs.te
 
 ifeq ($(shell [ $(POL_VERS) -ge 24 ] && echo true),true)
 TARGETS += test_bounds.te

--- a/policy/test_cgroupfs.te
+++ b/policy/test_cgroupfs.te
@@ -1,0 +1,13 @@
+#################################
+#
+# Policy for testing cgroupfs labeling
+#
+
+# Types for test file.
+type test_cgroup_t;
+files_type(test_cgroup_t)
+
+require {
+	type cgroup_t;
+}
+allow test_cgroup_t cgroup_t:filesystem { associate };

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,8 @@ SUBDIRS:= domain_trans entrypoint execshare exectrace execute_no_trans \
 	task_setnice task_setscheduler task_getscheduler task_getsid \
 	task_getpgid task_setpgid file ioctl capable_file capable_net \
 	capable_sys dyntrans dyntrace bounds nnp_nosuid mmap unix_socket \
-        inet_socket overlay checkreqprot mqueue mac_admin atsecure
+	inet_socket overlay checkreqprot mqueue mac_admin atsecure \
+	cgroupfs_label
 
 ifeq ($(shell grep -q cap_userns $(POLDEV)/include/support/all_perms.spt && echo true),true)
 ifneq ($(shell ./kvercmp $$(uname -r) 4.7),-1)

--- a/tests/cgroupfs_label/Makefile
+++ b/tests/cgroupfs_label/Makefile
@@ -1,0 +1,2 @@
+all:
+clean:

--- a/tests/cgroupfs_label/test
+++ b/tests/cgroupfs_label/test
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+
+use Test;
+BEGIN { plan tests => 2 }
+
+my $ret;
+
+# Create a new cgroupfs directory and relabel it.
+mkdir("/sys/fs/cgroup/unified/test");
+system("chcon -R -t test_cgroup_t /sys/fs/cgroup/unified/test");
+
+# Create a subdirectory in it.
+mkdir("/sys/fs/cgroup/unified/test/subdir");
+
+$ret =
+  system("test `secon -tf /sys/fs/cgroup/unified/test/subdir` = test_cgroup_t");
+ok( $ret, 0 );    # Did the subdirectory inherit the parent's label?
+
+$ret = system(
+"test `secon -tf /sys/fs/cgroup/unified/test/subdir/cgroup.type` = test_cgroup_t"
+);
+ok( $ret, 0 );    # Did also files in the subdirectory inherit the label?
+
+# Cleanup.
+rmdir("/sys/fs/cgroup/unified/test/subdir");
+rmdir("/sys/fs/cgroup/unified/test");
+
+exit;


### PR DESCRIPTION
This patch adds a tiny test that checks that labels of newly created
cgroupfs files/directories are correctly inherited from the parent.

Should start passing when the following issue is fixed:
https://github.com/SELinuxProject/selinux-kernel/issues/39

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>