### PR TITLE
BUG: wait for servers to finish before continuing

### DIFF
--- a/tests/binder/test
+++ b/tests/binder/test
@@ -98,6 +98,7 @@ sub service_end {
     my $flag = $service . "_flag";
 
     kill KILL, $pid;
+    waitpid $pid, 0;
     system("rm -f $basedir/$flag");
 }
 

--- a/tests/inet_socket/test
+++ b/tests/inet_socket/test
@@ -49,6 +49,7 @@ sub server_end {
     my ($pid) = @_;
 
     kill KILL, $pid;
+    waitpid $pid, 0;
     system("rm -f $basedir/flag");
 }
 

--- a/tests/sctp/test
+++ b/tests/sctp/test
@@ -79,6 +79,7 @@ sub server_end {
     my ($pid) = @_;
 
     kill KILL, $pid;
+    waitpid $pid, 0;
     system("rm -f $basedir/flag");
 }
 

--- a/tests/unix_socket/test
+++ b/tests/unix_socket/test
@@ -29,6 +29,7 @@ sub server_end {
     my ($pid) = @_;
 
     kill KILL, $pid;
+    waitpid $pid, 0;
     system("rm -f $basedir/flag");
 }
 


### PR DESCRIPTION
When we are starting a new server after killing an old one, there is a
possible race condition if the old server takes too long to tear down
and the new server fails to bind.

I've seen this happen in practice with the sctp test, but let's fix this
also in other tests where it makes sense logically.