### PR TITLE
BUG: fix corner case in SCTP asconf test

### DIFF
--- a/tests/sctp/test
+++ b/tests/sctp/test
@@ -37,7 +37,7 @@ BEGIN {
             }
         }
 
-        if ( $ipaddress[1] ne 0 ) {
+        if ( $ipaddress[1] ne 0 and $ipaddress[0] ne $ipaddress[1] ) {
             $test_count += 2;
             $test_asconf = 1;
         }


### PR DESCRIPTION
If a machine happens to have two interfaces with the same IP address
assigned, then the ASCONF tests are run even though they cannot work in
such case. Fix this by ensuring that the two addresses are different
before enabling the ASCONF tests.