### PR TITLE
RFE: use getfattr instead of ls -Z

### DIFF
--- a/tests/file/test
+++ b/tests/file/test
@@ -49,14 +49,8 @@ system "chcon -t fileop_exec_t $basedir/wait_io 2>&1 > /dev/null";
 #
 # Get the SID of the good file.
 #
-$output = `ls -Z $basedir/temp_file`;
-@arr = split( ' ', $output );
-if ( index( $arr[0], ":" ) != -1 ) {
-    $good_file_sid = $arr[0];
-}
-else {
-    $good_file_sid = $arr[3];
-}
+$good_file_sid =
+  `getfattr --only-values -n security.selinux $basedir/temp_file`;
 
 #
 # Attempt to access a restricted file as the 'good' domain.  The first test


### PR DESCRIPTION
`ls -Z` requires special handling due to different output across different coreutils versions. Instead use `getfattr(1)`, which can return the security context directly.

Resolves issue #8.

(This was the only occurrence of `ls -Z` in the whole testsuite.)