### PR TITLE
BUG: fix some build errors under refpolicy

### DIFF
--- a/policy/redhat/4/test_capable_file.te
+++ b/policy/redhat/4/test_capable_file.te
@@ -21,10 +21,10 @@ type test_nofcap_t, domain, capabledomain, testdomain;
 can_exec_any(capabledomain)
 
 # Allow all of these domains to be entered from admin roles.
-domain_trans(sysadm_t, test_file_t, capabledomain)
-domain_trans(sysadm_t, bin_t, capabledomain)
+domain_transition_pattern(sysadm_t, test_file_t, capabledomain)
+domain_transition_pattern(sysadm_t, bin_t, capabledomain)
 ifdef(`su.te', `
-domain_trans(sysadm_t, su_exec_t, capabledomain)
+domain_transition_pattern(sysadm_t, su_exec_t, capabledomain)
 ', `
 ')
 

--- a/policy/redhat/4/test_capable_net.te
+++ b/policy/redhat/4/test_capable_net.te
@@ -16,9 +16,9 @@ can_network(capabledomain)
 allow capabledomain reserved_port_t:tcp_socket name_bind;
 
 # Allow all of these domains to be entered from admin via certain utils.
-domain_trans(sysadm_t, sbin_t, capabledomain)
+domain_transition_pattern(sysadm_t, sbin_t, capabledomain)
 ifdef(`ifconfig.te', `
-domain_trans(sysadm_t, ifconfig_exec_t, capabledomain)
+domain_transition_pattern(sysadm_t, ifconfig_exec_t, capabledomain)
 ' , `
 ')
 

--- a/policy/redhat/4/test_dyntrace.te
+++ b/policy/redhat/4/test_dyntrace.te
@@ -15,7 +15,7 @@ type test_dyntrace_child_t, domain, dyntracedomain, testdomain;
 type test_dyntrace_notchild_t, domain, dyntracedomain, testdomain;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, dyntracedomain)
+domain_transition_pattern(sysadm_t, test_file_t, dyntracedomain)
 can_exec(dyntracedomain, test_file_t)
 
 # Grant the necessary permissions for the child domain.

--- a/policy/redhat/4/test_dyntrans.te
+++ b/policy/redhat/4/test_dyntrans.te
@@ -16,5 +16,5 @@ type test_dyntrans_todomain_t, domain, dyntransdomain, testdomain;
 allow test_dyntrans_fromdomain_t test_dyntrans_todomain_t:process dyntransition;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, dyntransdomain)
+domain_transition_pattern(sysadm_t, test_file_t, dyntransdomain)
 

--- a/policy/redhat/4/test_entrypoint.te
+++ b/policy/redhat/4/test_entrypoint.te
@@ -13,5 +13,5 @@ type test_entrypoint_t, domain, testdomain;
 can_exec(test_entrypoint_t,bin_t)
 
 # Allow this domain to be entered via its entrypoint type.
-domain_trans(sysadm_t, test_entrypoint_execute_t, test_entrypoint_t)
+domain_transition_pattern(sysadm_t, test_entrypoint_execute_t, test_entrypoint_t)
 

--- a/policy/redhat/4/test_execshare.te
+++ b/policy/redhat/4/test_execshare.te
@@ -13,12 +13,12 @@ type test_execshare_child_t, domain, execsharedomain, testdomain;
 type test_execshare_notchild_t, domain, execsharedomain, testdomain;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, execsharedomain)
+domain_transition_pattern(sysadm_t, test_file_t, execsharedomain)
 
 # Grant the necessary permissions for the child domain.
-domain_trans(test_execshare_parent_t, test_file_t, test_execshare_child_t)
+domain_transition_pattern(test_execshare_parent_t, test_file_t, test_execshare_child_t)
 allow test_execshare_parent_t test_execshare_child_t:process share;
 
 # Grant the notchild domain all the same permissions except for share.
-domain_trans(test_execshare_parent_t, test_file_t, test_execshare_notchild_t)
+domain_transition_pattern(test_execshare_parent_t, test_file_t, test_execshare_notchild_t)
 

--- a/policy/redhat/4/test_exectrace.te
+++ b/policy/redhat/4/test_exectrace.te
@@ -15,17 +15,17 @@ type test_exectrace_child_t, domain, exectracedomain, testdomain;
 type test_exectrace_notchild_t, domain, exectracedomain, testdomain;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, exectracedomain)
+domain_transition_pattern(sysadm_t, test_file_t, exectracedomain)
 
 # Grant the necessary permissions for the child domain.
-domain_trans(test_exectrace_parent_t, test_file_t, test_exectrace_child_t)
+domain_transition_pattern(test_exectrace_parent_t, test_file_t, test_exectrace_child_t)
 allow test_exectrace_parent_t test_exectrace_child_t:process { ptrace getattr };
 allow test_exectrace_parent_t test_exectrace_child_t:dir search;
 allow test_exectrace_parent_t test_exectrace_child_t:file read;
 allow test_exectrace_parent_t test_exectrace_child_t:file read;
 
 # Grant the notchild domain all the same permissions except for ptrace.
-domain_trans(test_exectrace_parent_t, test_file_t, test_exectrace_notchild_t)
+domain_transition_pattern(test_exectrace_parent_t, test_file_t, test_exectrace_notchild_t)
 allow test_exectrace_parent_t test_exectrace_notchild_t:process getattr;
 allow test_exectrace_parent_t test_exectrace_notchild_t:dir search;
 allow test_exectrace_parent_t test_exectrace_notchild_t:file read;

--- a/policy/redhat/4/test_execute_no_trans.te
+++ b/policy/redhat/4/test_execute_no_trans.te
@@ -13,7 +13,7 @@ type test_execute_notrans_denied_t, file_type, sysadmfile;
 type test_execute_notrans_t, domain, testdomain;
 
 # Allow this domain to be entered via the shell.
-domain_trans(sysadm_t, shell_exec_t, test_execute_notrans_t)
+domain_transition_pattern(sysadm_t, shell_exec_t, test_execute_notrans_t)
 
 #Allow test_execute_notrans permissions to the allowed type
 can_exec(test_execute_notrans_t,test_execute_notrans_allowed_t)

--- a/policy/redhat/4/test_fdreceive.te
+++ b/policy/redhat/4/test_fdreceive.te
@@ -21,7 +21,7 @@ type test_fdreceive_client2_t, domain, fdreceivedomain, testdomain;
 type test_fdreceive_server_t, domain, fdreceivedomain, testdomain;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, fdreceivedomain)
+domain_transition_pattern(sysadm_t, test_file_t, fdreceivedomain)
 
 # Grant the necessary permissions for the server domain.
 ## Create the Unix domain socket file.

--- a/policy/redhat/4/test_file.te
+++ b/policy/redhat/4/test_file.te
@@ -28,13 +28,13 @@ type nofileop_ra_file_t, file_type, sysadmfile;
 can_exec_any(fileopdomain)
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, test_file_t, fileopdomain)
-domain_trans(sysadm_t, bin_t, fileopdomain)
-domain_trans(sysadm_t, sbin_t, fileopdomain)
-domain_auto_trans(test_fileop_t, fileop_exec_t, fileop_t)
-domain_auto_trans(test_nofileop_t, fileop_exec_t, fileop_t)
+domain_transition_pattern(sysadm_t, test_file_t, fileopdomain)
+domain_transition_pattern(sysadm_t, bin_t, fileopdomain)
+domain_transition_pattern(sysadm_t, sbin_t, fileopdomain)
+domain_transition_pattern(test_fileop_t, fileop_exec_t, fileop_t)
+domain_transition_pattern(test_nofileop_t, fileop_exec_t, fileop_t)
 ifdef(`fsadm.te', `
-domain_trans(sysadm_t, fsadm_exec_t, fileopdomain)
+domain_transition_pattern(sysadm_t, fsadm_exec_t, fileopdomain)
 ', `
 ')
 

--- a/policy/redhat/4/test_inherit.te
+++ b/policy/redhat/4/test_inherit.te
@@ -21,13 +21,13 @@ type test_inherit_nouse_t, domain, inheritdomain, testdomain;
 type test_inherit_nowrite_t, domain, inheritdomain, testdomain;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, inheritdomain)
+domain_transition_pattern(sysadm_t, test_file_t, inheritdomain)
 
 # Grant the necessary permissions for the parent domain.
 allow test_inherit_parent_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the necessary permissions for the child domain.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_child_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_child_t)
 allow test_inherit_child_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the nouse domain all of the same permissions except for fd use.
@@ -36,6 +36,6 @@ allow test_inherit_nouse_t test_file_t:file { read getattr execute entrypoint };
 allow test_inherit_nouse_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the nowrite domain all of the same permissions except for file write.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
 allow test_inherit_nowrite_t test_inherit_file_t:file r_file_perms;
 

--- a/policy/redhat/4/test_ioctl.te
+++ b/policy/redhat/4/test_ioctl.te
@@ -17,8 +17,8 @@ can_exec_any(ioctldomain)
 
 # Allow all of these domains to be entered from sysadm domain
 # via a shell script in the test directory or by....
-domain_trans(sysadm_t, test_file_t, ioctldomain)
-domain_trans(sysadm_t, bin_t, ioctldomain)
+domain_transition_pattern(sysadm_t, test_file_t, ioctldomain)
+domain_transition_pattern(sysadm_t, bin_t, ioctldomain)
 
 # Allow the test domains some access to the temp file
 allow test_ioctl_t test_ioctl_file_t:file { read getattr setattr ioctl };

--- a/policy/redhat/4/test_ipc.te
+++ b/policy/redhat/4/test_ipc.te
@@ -54,8 +54,8 @@ allow domain tmpfs_t:file {read write};
 
 # Allow all of these domains to be entered from user domains.
 # via a shell script in the test directory or by another program.
-domain_trans(sysadm_t, test_file_t, ipcdomain)
-domain_trans(sysadm_t, bin_t, ipcdomain)
+domain_transition_pattern(sysadm_t, test_file_t, ipcdomain)
+domain_transition_pattern(sysadm_t, bin_t, ipcdomain)
 
 # Allow the user shell to read the /proc/PID entries for these domains.
 allow sysadm_t ipcdomain:dir r_dir_perms;

--- a/policy/redhat/4/test_link.te
+++ b/policy/redhat/4/test_link.te
@@ -45,5 +45,5 @@ allow test_nounlink2_t test_link_dir_t:dir { search getattr write };
 allow test_nounlink2_t test_link_file_t:file { getattr unlink };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, bin_t, test_link_domain)
+domain_transition_pattern(sysadm_t, bin_t, test_link_domain)
 

--- a/policy/redhat/4/test_mkdir.te
+++ b/policy/redhat/4/test_mkdir.te
@@ -34,5 +34,5 @@ allow test_nocreate_t test_mkdir_dir_t:dir { search getattr write add_name };
 allow test_nocreate_t test_create_dir_t:dir { search getattr };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, bin_t, test_mkdir_domain)
+domain_transition_pattern(sysadm_t, bin_t, test_mkdir_domain)
 

--- a/policy/redhat/4/test_open.te
+++ b/policy/redhat/4/test_open.te
@@ -19,5 +19,5 @@ type test_append_t, domain, test_open_domain, testdomain;
 allow test_append_t test_open_file_t:file { getattr append };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, test_file_t, test_open_domain)
+domain_transition_pattern(sysadm_t, test_file_t, test_open_domain)
 

--- a/policy/redhat/4/test_ptrace.te
+++ b/policy/redhat/4/test_ptrace.te
@@ -22,7 +22,7 @@ allow test_ptrace_traced_t test_ptrace_tracer_t:process sigchld;
 
 # Allow all of these domains to be entered from the sysadm domains.
 # via a program in the test directory.
-domain_trans(sysadm_t, test_file_t, ptracedomain)
+domain_transition_pattern(sysadm_t, test_file_t, ptracedomain)
 
 
 

--- a/policy/redhat/4/test_readlink.te
+++ b/policy/redhat/4/test_readlink.te
@@ -18,5 +18,5 @@ allow test_noreadlink_t test_readlink_file_t:file { getattr read };
 allow test_noreadlink_t test_readlink_link_t:lnk_file { getattr };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, ls_exec_t, test_readlink_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_readlink_domain)
 

--- a/policy/redhat/4/test_relabel.te
+++ b/policy/redhat/4/test_relabel.te
@@ -23,6 +23,6 @@ allow test_norelabelto_t test_relabel_oldtype_t:file { getattr relabelfrom };
 allow test_norelabelto_t test_relabel_newtype_t:file { getattr };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, bin_t, test_relabel_domain)
+domain_transition_pattern(sysadm_t, bin_t, test_relabel_domain)
 
 

--- a/policy/redhat/4/test_rename.te
+++ b/policy/redhat/4/test_rename.te
@@ -72,5 +72,5 @@ allow test_norename6_t test_rename_dst_dir_t:dir { search getattr write add_name
 allow test_norename6_t test_rename_dir_t:dir { getattr rename write };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, bin_t, test_rename_domain)
+domain_transition_pattern(sysadm_t, bin_t, test_rename_domain)
 

--- a/policy/redhat/4/test_rxdir.te
+++ b/policy/redhat/4/test_rxdir.te
@@ -17,5 +17,5 @@ allow test_xdir_t test_rxdir_dir_t:dir { getattr search };
 allow test_xdir_t test_rxdir_dir_t:file { getattr };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, ls_exec_t, test_rxdir_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_rxdir_domain)
 

--- a/policy/redhat/4/test_setattr.te
+++ b/policy/redhat/4/test_setattr.te
@@ -17,5 +17,5 @@ allow test_nosetattr_t self:capability chown;
 allow test_nosetattr_t test_setattr_file_t:file { getattr write };
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, bin_t, test_setattr_domain)
+domain_transition_pattern(sysadm_t, bin_t, test_setattr_domain)
 

--- a/policy/redhat/4/test_setnice.te
+++ b/policy/redhat/4/test_setnice.te
@@ -17,7 +17,7 @@ can_exec_any(setnicedomain)
 
 # Allow all of these domains to be entered from sysadm domain
 # via a shell script in the test directory or by....
-domain_trans(sysadm_t, test_file_t, setnicedomain)
-domain_trans(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
+domain_transition_pattern(sysadm_t, test_file_t, setnicedomain)
+domain_transition_pattern(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
 
 allow test_setnice_change_t test_setnice_set_t:process setsched;

--- a/policy/redhat/4/test_sigkill.te
+++ b/policy/redhat/4/test_sigkill.te
@@ -24,6 +24,6 @@ allow test_kill_signal_t test_kill_server_t:process signal;
 
 # Allow all of these domains to be entered from the sysadm domains,
 # via kill or a program in the test directory.
-domain_trans(sysadm_t, test_file_t, killdomain)
-domain_trans(sysadm_t, bin_t, killdomain)
+domain_transition_pattern(sysadm_t, test_file_t, killdomain)
+domain_transition_pattern(sysadm_t, bin_t, killdomain)
 

--- a/policy/redhat/4/test_socket.te
+++ b/policy/redhat/4/test_socket.te
@@ -81,10 +81,10 @@ allow socketdomain test_file_t:sock_file rw_file_perms;
 
 # Allow all of these domains to be entered from user domains.
 # via a shell script in the test directory.
-domain_trans(sysadm_t, test_file_t, socketdomain)
+domain_transition_pattern(sysadm_t, test_file_t, socketdomain)
 
 # Also allow entry via some other programs.
-domain_trans(sysadm_t, bin_t, socketdomain)
+domain_transition_pattern(sysadm_t, bin_t, socketdomain)
 
 # Allow the user shell to read the /proc/PID entries for these domains.
 allow sysadm_t socketdomain:dir r_dir_perms;

--- a/policy/redhat/4/test_stat.te
+++ b/policy/redhat/4/test_stat.te
@@ -14,5 +14,5 @@ allow test_stat_t test_stat_file_t:file getattr;
 type test_nostat_t, domain, test_stat_domain, testdomain;
 
 # Allow all of these domains to be entered from sysadm domain
-domain_trans(sysadm_t, ls_exec_t, test_stat_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_stat_domain)
 

--- a/policy/redhat/4/test_sysctl.te
+++ b/policy/redhat/4/test_sysctl.te
@@ -11,7 +11,7 @@ type test_nosysctl_t, domain, sysctldomain, testdomain;
 
 # Allow all of these domains to be entered from sysadm domain
 # via /sbin/sysctl.
-domain_trans(sysadm_t, sbin_t, sysctldomain)
+domain_transition_pattern(sysadm_t, sbin_t, sysctldomain)
 
 # Allow the first domain to perform sysctl operations.
 can_sysctl(test_sysctl_t)

--- a/policy/redhat/4/test_task_create.te
+++ b/policy/redhat/4/test_task_create.te
@@ -35,5 +35,5 @@ allow test_create_no_t sysadm_tty_device_t:chr_file rw_file_perms;
 # Allow domain to be entered from the sysadm domain.
 role sysadm_r types test_create_d;
 role system_r types test_create_d;
-domain_trans(sysadm_t, test_file_t, test_create_d)
+domain_transition_pattern(sysadm_t, test_file_t, test_create_d)
 

--- a/policy/redhat/4/test_task_getpgid.te
+++ b/policy/redhat/4/test_task_getpgid.te
@@ -15,7 +15,7 @@ type test_getpgid_no_t, domain, test_getpgid_d, testdomain;
 
 
 # Allow domain to be entered from the sysadm domain
-domain_trans(sysadm_t, test_file_t, test_getpgid_d)
+domain_transition_pattern(sysadm_t, test_file_t, test_getpgid_d)
 
 # Give test_getpgid_yes_t the permission needed.
 allow test_getpgid_yes_t test_getpgid_target_t:process getpgid;

--- a/policy/redhat/4/test_task_getsched.te
+++ b/policy/redhat/4/test_task_getsched.te
@@ -15,7 +15,7 @@ type test_getsched_no_t, domain, test_getsched_d, testdomain;
 
 
 # Allow domain to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, test_getsched_d)
+domain_transition_pattern(sysadm_t, test_file_t, test_getsched_d)
 
 # Give test_getsched_yes_t the permission needed.
 allow test_getsched_yes_t test_getsched_target_t:process getsched;

--- a/policy/redhat/4/test_task_getsid.te
+++ b/policy/redhat/4/test_task_getsid.te
@@ -15,7 +15,7 @@ type test_getsid_no_t, domain, test_getsid_d, testdomain;
 
 
 # Allow domain to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, test_getsid_d)
+domain_transition_pattern(sysadm_t, test_file_t, test_getsid_d)
 
 # Give test_getsid_yes_t the permission needed.
 allow test_getsid_yes_t test_getsid_target_t:process getsession;

--- a/policy/redhat/4/test_task_setpgid.te
+++ b/policy/redhat/4/test_task_setpgid.te
@@ -32,5 +32,5 @@ allow test_setpgid_no_t sysadm_tty_device_t:chr_file rw_file_perms;
 # Allow domain to be entered from the sysadm domain.
 role sysadm_r types test_setpgid_d;
 role system_r types test_setpgid_d;
-domain_trans(sysadm_t, test_file_t, test_setpgid_d)
+domain_transition_pattern(sysadm_t, test_file_t, test_setpgid_d)
 

--- a/policy/redhat/4/test_task_setsched.te
+++ b/policy/redhat/4/test_task_setsched.te
@@ -15,7 +15,7 @@ type test_setsched_yes_t, domain, test_setsched_d, testdomain;
 type test_setsched_no_t, domain, test_setsched_d, testdomain;
 
 # Allow domain to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, test_setsched_d)
+domain_transition_pattern(sysadm_t, test_file_t, test_setsched_d)
 
 # Allow these domains to execute renice.
 allow test_setsched_d bin_t:file rx_file_perms;

--- a/policy/redhat/4/test_transition.te
+++ b/policy/redhat/4/test_transition.te
@@ -13,8 +13,8 @@ type test_transition_notfromdomain_t, domain, transitiondomain, testdomain;
 type test_transition_todomain_t, domain, transitiondomain, testdomain;
 
 # Allow the fromdomain to transition to the new domain.
-domain_trans(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
+domain_transition_pattern(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, bin_t, transitiondomain)
+domain_transition_pattern(sysadm_t, bin_t, transitiondomain)
 

--- a/policy/redhat/4/test_wait.te
+++ b/policy/redhat/4/test_wait.te
@@ -13,11 +13,11 @@ type test_wait_child_t, domain, waitdomain, testdomain;
 type test_wait_notchild_t, domain, waitdomain, testdomain;
 
 # Allow all of these domains to be entered from the sysadm domain.
-domain_trans(sysadm_t, test_file_t, waitdomain)
+domain_transition_pattern(sysadm_t, test_file_t, waitdomain)
 
 # Grant permissions for a domain transition from parent to child,
 # including the ability to wait on the child.
-domain_trans(test_wait_parent_t, test_file_t, test_wait_child_t)
+domain_transition_pattern(test_wait_parent_t, test_file_t, test_wait_child_t)
 
 # Permit the parent to transition to the notchild, but don't
 # grant the permission to wait on it.

--- a/policy/redhat/5/test_capable_net.te
+++ b/policy/redhat/5/test_capable_net.te
@@ -50,7 +50,7 @@ userdom_sysadm_sbin_spec_domtrans_to(capabledomain)
 require {
 	type ifconfig_exec_t;
 }
-domain_trans(sysadm_t, ifconfig_exec_t, capabledomain)
+domain_transition_pattern(sysadm_t, ifconfig_exec_t, capabledomain)
 domain_entry_file(capabledomain, ifconfig_exec_t)
 
 # Permissions for the good domain

--- a/policy/redhat/5/test_file.te
+++ b/policy/redhat/5/test_file.te
@@ -68,13 +68,13 @@ corecmd_sbin_entry_type(fileopdomain)
 userdom_sysadm_sbin_spec_domtrans_to(fileopdomain)
 
 allow fileop_t fileop_exec_t:file entrypoint;
-domain_auto_trans(test_fileop_t, fileop_exec_t, fileop_t)
+domain_transition_pattern(test_fileop_t, fileop_exec_t, fileop_t)
 allow test_fileop_t fileop_t:fd use;
 allow fileop_t test_fileop_t:fd use;
 allow fileop_t test_fileop_t:fifo_file rw_file_perms;
 allow fileop_t test_fileop_t:process sigchld;
 
-domain_auto_trans(test_nofileop_t, fileop_exec_t, fileop_t)
+domain_transition_pattern(test_nofileop_t, fileop_exec_t, fileop_t)
 allow test_nofileop_t fileop_t:fd use;
 allow fileop_t test_nofileop_t:fd use;
 allow fileop_t test_nofileop_t:fifo_file rw_file_perms;

--- a/policy/redhat/5/test_inherit.te
+++ b/policy/redhat/5/test_inherit.te
@@ -43,7 +43,7 @@ userdom_sysadm_entry_spec_domtrans_to(inheritdomain)
 allow test_inherit_parent_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the necessary permissions for the child domain.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_child_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_child_t)
 allow test_inherit_parent_t test_inherit_child_t:fd use;
 allow test_inherit_child_t test_inherit_parent_t:fd use;
 allow test_inherit_child_t test_inherit_parent_t:fifo_file rw_file_perms;
@@ -56,7 +56,7 @@ allow test_inherit_nouse_t test_file_t:file { read getattr execute entrypoint };
 allow test_inherit_nouse_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the nowrite domain all of the same permissions except for file write.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
 allow test_inherit_parent_t test_inherit_nowrite_t:fd use;
 allow test_inherit_nowrite_t test_inherit_parent_t:fd use;
 allow test_inherit_nowrite_t test_inherit_parent_t:fifo_file rw_file_perms;

--- a/policy/redhat/5/test_readlink.te
+++ b/policy/redhat/5/test_readlink.te
@@ -32,5 +32,5 @@ allow test_noreadlink_t test_readlink_link_t:lnk_file { getattr };
 require {
 	type ls_exec_t;
 }
-domain_trans(sysadm_t, ls_exec_t, test_readlink_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_readlink_domain)
 domain_entry_file(test_readlink_domain, ls_exec_t)

--- a/policy/redhat/5/test_rxdir.te
+++ b/policy/redhat/5/test_rxdir.te
@@ -31,4 +31,4 @@ require {
 	type ls_exec_t;
 }
 domain_entry_file(test_rxdir_domain, ls_exec_t)
-domain_trans(sysadm_t, ls_exec_t, test_rxdir_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_rxdir_domain)

--- a/policy/redhat/5/test_setnice.te
+++ b/policy/redhat/5/test_setnice.te
@@ -36,8 +36,8 @@ libs_exec_lib_files(setnicedomain)
 # Allow all of these domains to be entered from sysadm domain
 # via a shell script in the test directory or by....
 miscfiles_domain_entry_test_files(setnicedomain)
-domain_trans(sysadm_t, test_file_t, setnicedomain)
-domain_trans(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
+domain_transition_pattern(sysadm_t, test_file_t, setnicedomain)
+domain_transition_pattern(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
 allow test_setnice_change_t test_setnice_set_t:fd use;
 allow test_setnice_set_t test_setnice_change_t:fd use;
 allow test_setnice_set_t test_setnice_change_t:fifo_file rw_file_perms;

--- a/policy/redhat/5/test_stat.te
+++ b/policy/redhat/5/test_stat.te
@@ -27,5 +27,5 @@ typeattribute test_nostat_t testdomain;
 require {
 	type ls_exec_t;
 }
-domain_trans(sysadm_t, ls_exec_t, test_stat_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_stat_domain)
 domain_entry_file(test_stat_domain, ls_exec_t)

--- a/policy/redhat/5/test_transition.te
+++ b/policy/redhat/5/test_transition.te
@@ -25,7 +25,7 @@ typeattribute test_transition_todomain_t testdomain;
 
 # Allow the fromdomain to transition to the new domain.
 corecmd_bin_entry_type(transitiondomain)
-domain_trans(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
+domain_transition_pattern(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
 allow test_transition_fromdomain_t test_transition_todomain_t:fd use;
 allow test_transition_todomain_t test_transition_fromdomain_t:fd use;
 

--- a/policy/redhat/5/test_wait.te
+++ b/policy/redhat/5/test_wait.te
@@ -29,7 +29,7 @@ userdom_sysadm_entry_spec_domtrans_to(waitdomain)
 
 # Grant permissions for a domain transition from parent to child,
 # including the ability to wait on the child.
-domain_trans(test_wait_parent_t, test_file_t, test_wait_child_t)
+domain_transition_pattern(test_wait_parent_t, test_file_t, test_wait_child_t)
 allow test_wait_parent_t test_wait_child_t:fd use;
 allow test_wait_child_t test_wait_parent_t:fd use;
 allow test_wait_child_t test_wait_parent_t:fifo_file rw_file_perms;

--- a/policy/test_atsecure.te
+++ b/policy/test_atsecure.te
@@ -32,8 +32,8 @@ corecmd_bin_entry_type(atsecuredomain)
 corecmd_shell_entry_type(atsecuredomain)
 corecmd_exec_bin(atsecuredomain)
 domain_entry_file(test_atsecure_newdomain_t, test_file_t)
-domain_trans(test_atsecure_denied_t, test_file_t, test_atsecure_newdomain_t)
-domain_trans(test_atsecure_allowed_t, test_file_t, test_atsecure_newdomain_t)
+domain_transition_pattern(test_atsecure_denied_t, test_file_t, test_atsecure_newdomain_t)
+domain_transition_pattern(test_atsecure_allowed_t, test_file_t, test_atsecure_newdomain_t)
 allow test_atsecure_newdomain_t test_atsecure_denied_t:fd use;
 allow test_atsecure_newdomain_t test_atsecure_allowed_t:fd use;
 allow_map(atsecuredomain, test_file_t, file)

--- a/policy/test_capable_net.te
+++ b/policy/test_capable_net.te
@@ -53,7 +53,7 @@ sysadm_bin_spec_domtrans_to(capabledomain)
 require {
 	type ifconfig_exec_t;
 }
-domain_trans(sysadm_t, ifconfig_exec_t, capabledomain)
+domain_transition_pattern(sysadm_t, ifconfig_exec_t, capabledomain)
 domain_entry_file(capabledomain, ifconfig_exec_t)
 
 # Permissions for the good domain

--- a/policy/test_execute_no_trans.te
+++ b/policy/test_execute_no_trans.te
@@ -24,4 +24,4 @@ userdom_sysadm_entry_spec_domtrans_to(test_execute_notrans_t)
 
 #Allow test_execute_notrans permissions to the allowed type
 can_exec(test_execute_notrans_t,test_execute_notrans_allowed_t)
-allow test_execute_notrans_t test_execute_notrans_denied_t:file mmap_file_perms;
+allow test_execute_notrans_t test_execute_notrans_denied_t:file mmap_exec_file_perms;

--- a/policy/test_file.te
+++ b/policy/test_file.te
@@ -67,13 +67,13 @@ corecmd_bin_entry_type(fileopdomain)
 sysadm_bin_spec_domtrans_to(fileopdomain)
 
 domain_entry_file(fileop_t, fileop_exec_t)
-domain_auto_trans(test_fileop_t, fileop_exec_t, fileop_t)
+domain_transition_pattern(test_fileop_t, fileop_exec_t, fileop_t)
 allow test_fileop_t fileop_t:fd use;
 allow fileop_t test_fileop_t:fd use;
 allow fileop_t test_fileop_t:fifo_file rw_file_perms;
 allow fileop_t test_fileop_t:process sigchld;
 
-domain_auto_trans(test_nofileop_t, fileop_exec_t, fileop_t)
+domain_transition_pattern(test_nofileop_t, fileop_exec_t, fileop_t)
 allow test_nofileop_t fileop_t:fd use;
 allow fileop_t test_nofileop_t:fd use;
 allow fileop_t test_nofileop_t:fifo_file rw_file_perms;

--- a/policy/test_inherit.te
+++ b/policy/test_inherit.te
@@ -47,7 +47,7 @@ userdom_sysadm_entry_spec_domtrans_to(inheritdomain)
 allow test_inherit_parent_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the necessary permissions for the child domain.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_child_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_child_t)
 allow test_inherit_parent_t test_inherit_child_t:fd use;
 allow test_inherit_child_t test_inherit_parent_t:fd use;
 allow test_inherit_child_t test_inherit_parent_t:fifo_file rw_file_perms;
@@ -60,7 +60,7 @@ allow test_inherit_nouse_t test_file_t:file { read getattr execute entrypoint };
 allow test_inherit_nouse_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the nowrite domain all of the same permissions except for file write.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
 allow test_inherit_parent_t test_inherit_nowrite_t:fd use;
 allow test_inherit_nowrite_t test_inherit_parent_t:fd use;
 allow test_inherit_nowrite_t test_inherit_parent_t:fifo_file rw_file_perms;

--- a/policy/test_readlink.te
+++ b/policy/test_readlink.te
@@ -34,5 +34,5 @@ allow test_noreadlink_t test_readlink_link_t:lnk_file { getattr };
 require {
 	type ls_exec_t;
 }
-domain_trans(sysadm_t, ls_exec_t, test_readlink_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_readlink_domain)
 domain_entry_file(test_readlink_domain, ls_exec_t)

--- a/policy/test_rxdir.te
+++ b/policy/test_rxdir.te
@@ -33,4 +33,4 @@ require {
 	type ls_exec_t;
 }
 domain_entry_file(test_rxdir_domain, ls_exec_t)
-domain_trans(sysadm_t, ls_exec_t, test_rxdir_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_rxdir_domain)

--- a/policy/test_setnice.te
+++ b/policy/test_setnice.te
@@ -38,8 +38,8 @@ libs_exec_lib_files(setnicedomain)
 # Allow all of these domains to be entered from sysadm domain
 # via a shell script in the test directory or by....
 miscfiles_domain_entry_test_files(setnicedomain)
-domain_trans(sysadm_t, test_file_t, setnicedomain)
-domain_trans(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
+domain_transition_pattern(sysadm_t, test_file_t, setnicedomain)
+domain_transition_pattern(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
 allow test_setnice_change_t test_setnice_set_t:fd use;
 allow test_setnice_set_t test_setnice_change_t:fd use;
 allow test_setnice_set_t test_setnice_change_t:fifo_file rw_file_perms;

--- a/policy/test_stat.te
+++ b/policy/test_stat.te
@@ -29,5 +29,5 @@ typeattribute test_nostat_t testdomain;
 require {
 	type ls_exec_t;
 }
-domain_trans(sysadm_t, ls_exec_t, test_stat_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_stat_domain)
 domain_entry_file(test_stat_domain, ls_exec_t)

--- a/policy/test_transition.te
+++ b/policy/test_transition.te
@@ -28,7 +28,7 @@ typeattribute test_transition_todomain_t testdomain;
 
 # Allow the fromdomain to transition to the new domain.
 corecmd_bin_entry_type(transitiondomain)
-domain_trans(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
+domain_transition_pattern(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
 allow test_transition_fromdomain_t test_transition_todomain_t:fd use;
 allow test_transition_todomain_t test_transition_fromdomain_t:fd use;
 


### PR DESCRIPTION
Replace deprecated macros with new ones. Fedora's policy has both; refpolicy just the new ones.

Partially addresses issue #57.