### PR TITLE
selinux-testsuite: drop use of userdom_read_inherited_user_tmp_files

### DIFF
--- a/policy/test_overlayfs.te
+++ b/policy/test_overlayfs.te
@@ -50,7 +50,6 @@ fs_mount_xattr_fs(test_overlay_mounter_t)
 corecmd_shell_entry_type(test_overlay_mounter_t)
 corecmd_exec_bin(test_overlay_mounter_t)
 
-userdom_read_inherited_user_tmp_files(test_overlay_mounter_t)
 userdom_search_admin_dir(test_overlay_mounter_t)
 userdom_search_user_home_content(test_overlay_mounter_t)
 
@@ -123,7 +122,6 @@ corecmd_exec_bin(test_overlay_client_t)
 kernel_read_system_state(test_overlay_client_t)
 kernel_read_proc_symlinks(test_overlay_client_t)
 
-userdom_read_inherited_user_tmp_files(test_overlay_client_t)
 userdom_search_admin_dir(test_overlay_client_t)
 userdom_search_user_home_content(test_overlay_client_t)
 


### PR DESCRIPTION
The overlay test policy had two calls to the
userdom_read_inherited_user_tmp_files() policy interface.
This is a Fedora-specific interface that is not present in
refpolicy and therefore prevents building the test policy on
other distributions.  Further, there is no clear reason why
the calls to this interface are needed for the overlay tests;
the tests are not inheriting open /tmp files.  Remove the
calls.

Fixes: https://github.com/SELinuxProject/selinux-testsuite/issues/57
Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>