### PR TITLE
policy: fix some build errors under refpolicy

### DIFF
--- a/policy/test_atsecure.te
+++ b/policy/test_atsecure.te
@@ -32,8 +32,8 @@ corecmd_bin_entry_type(atsecuredomain)
 corecmd_shell_entry_type(atsecuredomain)
 corecmd_exec_bin(atsecuredomain)
 domain_entry_file(test_atsecure_newdomain_t, test_file_t)
-domain_trans(test_atsecure_denied_t, test_file_t, test_atsecure_newdomain_t)
-domain_trans(test_atsecure_allowed_t, test_file_t, test_atsecure_newdomain_t)
+domain_transition_pattern(test_atsecure_denied_t, test_file_t, test_atsecure_newdomain_t)
+domain_transition_pattern(test_atsecure_allowed_t, test_file_t, test_atsecure_newdomain_t)
 allow test_atsecure_newdomain_t test_atsecure_denied_t:fd use;
 allow test_atsecure_newdomain_t test_atsecure_allowed_t:fd use;
 allow_map(atsecuredomain, test_file_t, file)

--- a/policy/test_capable_net.te
+++ b/policy/test_capable_net.te
@@ -53,7 +53,7 @@ sysadm_bin_spec_domtrans_to(capabledomain)
 require {
 	type ifconfig_exec_t;
 }
-domain_trans(sysadm_t, ifconfig_exec_t, capabledomain)
+domain_transition_pattern(sysadm_t, ifconfig_exec_t, capabledomain)
 domain_entry_file(capabledomain, ifconfig_exec_t)
 
 # Permissions for the good domain

--- a/policy/test_file.te
+++ b/policy/test_file.te
@@ -67,13 +67,13 @@ corecmd_bin_entry_type(fileopdomain)
 sysadm_bin_spec_domtrans_to(fileopdomain)
 
 domain_entry_file(fileop_t, fileop_exec_t)
-domain_auto_trans(test_fileop_t, fileop_exec_t, fileop_t)
+domain_auto_transition_pattern(test_fileop_t, fileop_exec_t, fileop_t)
 allow test_fileop_t fileop_t:fd use;
 allow fileop_t test_fileop_t:fd use;
 allow fileop_t test_fileop_t:fifo_file rw_file_perms;
 allow fileop_t test_fileop_t:process sigchld;
 
-domain_auto_trans(test_nofileop_t, fileop_exec_t, fileop_t)
+domain_auto_transition_pattern(test_nofileop_t, fileop_exec_t, fileop_t)
 allow test_nofileop_t fileop_t:fd use;
 allow fileop_t test_nofileop_t:fd use;
 allow fileop_t test_nofileop_t:fifo_file rw_file_perms;

--- a/policy/test_inherit.te
+++ b/policy/test_inherit.te
@@ -47,7 +47,7 @@ userdom_sysadm_entry_spec_domtrans_to(inheritdomain)
 allow test_inherit_parent_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the necessary permissions for the child domain.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_child_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_child_t)
 allow test_inherit_parent_t test_inherit_child_t:fd use;
 allow test_inherit_child_t test_inherit_parent_t:fd use;
 allow test_inherit_child_t test_inherit_parent_t:fifo_file rw_file_perms;
@@ -60,7 +60,7 @@ allow test_inherit_nouse_t test_file_t:file { read getattr execute entrypoint };
 allow test_inherit_nouse_t test_inherit_file_t:file rw_file_perms;
 
 # Grant the nowrite domain all of the same permissions except for file write.
-domain_trans(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
+domain_transition_pattern(test_inherit_parent_t, test_file_t, test_inherit_nowrite_t)
 allow test_inherit_parent_t test_inherit_nowrite_t:fd use;
 allow test_inherit_nowrite_t test_inherit_parent_t:fd use;
 allow test_inherit_nowrite_t test_inherit_parent_t:fifo_file rw_file_perms;

--- a/policy/test_readlink.te
+++ b/policy/test_readlink.te
@@ -34,5 +34,5 @@ allow test_noreadlink_t test_readlink_link_t:lnk_file { getattr };
 require {
 	type ls_exec_t;
 }
-domain_trans(sysadm_t, ls_exec_t, test_readlink_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_readlink_domain)
 domain_entry_file(test_readlink_domain, ls_exec_t)

--- a/policy/test_rxdir.te
+++ b/policy/test_rxdir.te
@@ -33,4 +33,4 @@ require {
 	type ls_exec_t;
 }
 domain_entry_file(test_rxdir_domain, ls_exec_t)
-domain_trans(sysadm_t, ls_exec_t, test_rxdir_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_rxdir_domain)

--- a/policy/test_setnice.te
+++ b/policy/test_setnice.te
@@ -38,8 +38,8 @@ libs_exec_lib_files(setnicedomain)
 # Allow all of these domains to be entered from sysadm domain
 # via a shell script in the test directory or by....
 miscfiles_domain_entry_test_files(setnicedomain)
-domain_trans(sysadm_t, test_file_t, setnicedomain)
-domain_trans(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
+domain_transition_pattern(sysadm_t, test_file_t, setnicedomain)
+domain_transition_pattern(test_setnice_change_t, test_file_t, {test_setnice_set_t test_setnice_noset_t})
 allow test_setnice_change_t test_setnice_set_t:fd use;
 allow test_setnice_set_t test_setnice_change_t:fd use;
 allow test_setnice_set_t test_setnice_change_t:fifo_file rw_file_perms;

--- a/policy/test_stat.te
+++ b/policy/test_stat.te
@@ -29,5 +29,5 @@ typeattribute test_nostat_t testdomain;
 require {
 	type ls_exec_t;
 }
-domain_trans(sysadm_t, ls_exec_t, test_stat_domain)
+domain_transition_pattern(sysadm_t, ls_exec_t, test_stat_domain)
 domain_entry_file(test_stat_domain, ls_exec_t)

--- a/policy/test_transition.te
+++ b/policy/test_transition.te
@@ -28,7 +28,7 @@ typeattribute test_transition_todomain_t testdomain;
 
 # Allow the fromdomain to transition to the new domain.
 corecmd_bin_entry_type(transitiondomain)
-domain_trans(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
+domain_transition_pattern(test_transition_fromdomain_t,bin_t,test_transition_todomain_t)
 allow test_transition_fromdomain_t test_transition_todomain_t:fd use;
 allow test_transition_todomain_t test_transition_fromdomain_t:fd use;
 


### PR DESCRIPTION
Replace deprecated macros with new ones. Fedora's policy has both;
refpolicy just the new ones.

Partially addresses issue #57.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>