### PR TITLE
tests/Makefile: check if BPF library is installed

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,8 +43,10 @@ endif
 
 ifeq ($(shell grep -q bpf $(POLDEV)/include/support/all_perms.spt && echo true),true)
 ifneq ($(shell ./kvercmp $$(uname -r) 4.15),-1)
+ifneq (,$(wildcard $(INCLUDEDIR)/bpf/bpf.h))
 SUBDIRS += bpf
 export CFLAGS += -DHAVE_BPF
+endif
 endif
 endif
 


### PR DESCRIPTION
Check for the existence of the <bpf/bpf.h> header before enabling BPF
testing. Otherwise building the tests fails in an environment where
the kernel and policy support BPF, but the library is not installed.

Fixes: 8f0f980a4ad5 ("selinux-testsuite: Add BPF tests")
Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>