### PR TITLE
Fix refpolicy build & build test_policy.pp in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 
-dist: xenial
+dist: bionic
 
 addons:
   apt:
@@ -8,6 +8,14 @@ addons:
       - astyle
       - libselinux1-dev
       - libsctp-dev
+      - checkpolicy
+      - semodule-utils
+
+cache:
+  directories:
+    - selinux-policy
+    - container-selinux
+    - refpolicy
 
 before_install:
   # FYI: known good with HEAD at 8551fc60fc515cd290ba38ee8c758c1f4df52b56
@@ -17,7 +25,19 @@ before_install:
      perl Makefile.PL &&
      make &&
      sudo make install)
+  # install libbpf from sources
+  - git clone https://github.com/libbpf/libbpf
+  - (cd libbpf/src && make PREFIX=/usr/local)
+  - (cd libbpf/src && sudo make install PREFIX=/usr/local)
+  # install Fedora policy and refpolicy
+  - bash travis-ci/setup-policy-fedora.sh
+  - bash travis-ci/setup-policy-refpolicy.sh
+  # establish a fake "selinuxfs" mount (policy/Makefile just greps for selinuxfs)
+  - sudo mkdir -p /tmp/fake-selinuxfs
+  - sudo mount -t tmpfs tmpfs /tmp/fake-selinuxfs
+  - echo 31 >/tmp/fake-selinuxfs/policyvers
 
 script:
   - tools/check-syntax -f && git diff --exit-code
-  - make
+  - bash travis-ci/enable-policy.sh targeted  && make POLDEV=/usr/share/selinux/targeted
+  - bash travis-ci/enable-policy.sh refpolicy && make POLDEV=/usr/share/selinux/refpolicy

--- a/policy/test_overlayfs.te
+++ b/policy/test_overlayfs.te
@@ -50,8 +50,7 @@ fs_mount_xattr_fs(test_overlay_mounter_t)
 corecmd_shell_entry_type(test_overlay_mounter_t)
 corecmd_exec_bin(test_overlay_mounter_t)
 
-userdom_search_admin_dir(test_overlay_mounter_t)
-userdom_search_user_home_content(test_overlay_mounter_t)
+userdom_search_generic_user_home_dirs(test_overlay_mounter_t)
 
 mount_exec(test_overlay_mounter_t)
 mount_rw_pid_files(test_overlay_mounter_t)
@@ -122,8 +121,7 @@ corecmd_exec_bin(test_overlay_client_t)
 kernel_read_system_state(test_overlay_client_t)
 kernel_read_proc_symlinks(test_overlay_client_t)
 
-userdom_search_admin_dir(test_overlay_client_t)
-userdom_search_user_home_content(test_overlay_client_t)
+userdom_search_generic_user_home_dirs(test_overlay_client_t)
 
 fs_getattr_xattr_fs(test_overlay_client_t)
 

--- a/policy/test_policy.if
+++ b/policy/test_policy.if
@@ -61,8 +61,13 @@ interface(`userdom_sysadm_entry_spec_domtrans_to',`
 ')
 ')
 
-ifdef(`userdom_search_generic_user_home_dirs', `', ` dnl
+ifdef(`userdom_search_admin_dir', ` dnl
 interface(`userdom_search_generic_user_home_dirs', `
-    userdom_search_user_home_dirs($1)
+    userdom_search_user_home_content($1)
+    userdom_search_admin_dir($1)
+')
+', ` dnl
+interface(`userdom_search_generic_user_home_dirs', `
+    userdom_search_user_home_content($1)
 ')
 ')

--- a/policy/test_policy.if
+++ b/policy/test_policy.if
@@ -71,3 +71,17 @@ interface(`userdom_search_generic_user_home_dirs', `
     userdom_search_user_home_content($1)
 ')
 ')
+
+# Workarounds for refpolicy:
+
+ifdef(`dev_rw_infiniband_dev', `', ` dnl
+interface(`dev_rw_infiniband_dev', `
+    dev_rw_generic_files($1)
+')
+')
+
+ifdef(`mount_rw_pid_files', `', ` dnl
+interface(`mount_rw_pid_files', `
+    mount_rw_runtime_files($1)
+')
+')

--- a/travis-ci/enable-policy.sh
+++ b/travis-ci/enable-policy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# create a dummy /etc/selinux/config
+sudo mkdir -p /etc/selinux
+sudo tee /etc/selinux/config >/dev/null <<EOF
+SELINUX=disabled
+SELINUXTYPE=$1
+EOF

--- a/travis-ci/setup-policy-fedora.sh
+++ b/travis-ci/setup-policy-fedora.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+if ! [ -d selinux-policy/.git ]; then
+	git clone --recursive https://github.com/fedora-selinux/selinux-policy
+	(cd selinux-policy/policy/modules/contrib && git checkout rawhide)
+else
+	(cd selinux-policy && git pull || { git checkout '*' && git pull; })
+	(cd selinux-policy/policy/modules/contrib && git pull)
+fi
+
+if ! [ -d container-selinux/.git ]; then
+	git clone https://github.com/containers/container-selinux.git
+	for f in container.if container.te; do
+		ln -s ../../../../container-selinux/$f \
+			selinux-policy/policy/modules/contrib/$f
+	done
+else
+	(cd container-selinux && git pull)
+fi
+
+cd selinux-policy
+
+grep -q refpolicy build.conf && sed -i 's/refpolicy/targeted/' build.conf
+grep -q '^portcon sctp' policy/modules/kernel/corenetwork.te.in && \
+	sed -i '/^portcon sctp/d' policy/modules/kernel/corenetwork.te.in
+
+[ -f policy/modules.conf ] || make conf
+
+make -j`nproc --all`
+sudo make install install-headers
+
+# workaround for different Makefile location in Fedora RPMs
+sudo ln -s include/Makefile /usr/share/selinux/targeted/Makefile

--- a/travis-ci/setup-policy-refpolicy.sh
+++ b/travis-ci/setup-policy-refpolicy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+if ! [ -d refpolicy/.git ]; then
+	git clone https://github.com/SELinuxProject/refpolicy
+else
+	git pull || { git checkout '*' && git pull; }
+fi
+
+cd refpolicy
+
+[ -f policy/modules.conf ] || make conf
+
+grep -q '^portcon sctp' policy/modules/kernel/corenetwork.te.in && \
+	sed -i '/^portcon sctp/d' policy/modules/kernel/corenetwork.te.in
+
+make -j`nproc --all`
+sudo make install install-headers
+
+# workaround for different Makefile location in Fedora RPMs
+sudo ln -s include/Makefile /usr/share/selinux/refpolicy/Makefile


### PR DESCRIPTION
This series fixes the remaining test_policy.pp build errors under
refpolicy and enables building the test policy under both Fedora policy
and refpolicy in Travis CI.