### PR TITLE
tests/binder: Build only for 4.11 and later kernels

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -54,7 +54,9 @@ SUBDIRS += prlimit
 endif
 
 ifeq ($(shell grep -q binder $(POLDEV)/include/support/all_perms.spt && test -e $(INCLUDEDIR)/linux/android/binder.h && echo true),true)
+ifneq ($(shell ./kvercmp $$(uname -r) 4.11),-1)
 SUBDIRS += binder
+endif
 endif
 
 ifeq ($(shell grep -q bpf $(POLDEV)/include/support/all_perms.spt && echo true),true)


### PR DESCRIPTION
Following compilation errors occur when building the tests with userspace headers exported from kernel 4.4:

```
binder_common.c:111:14: error: ‘const struct flat_binder_object’ has no
member named ‘hdr’
   switch (obj->hdr.type) {
              ^
client.c:58:9: error: dereferencing pointer to incomplete type
  if (obj->hdr.type != BINDER_TYPE_FD) {
         ^
```

It's been checked that member `hdr` of `struct flat_binder_object` and `struct binder_fd_object` were both introduced by commit feba3900cabb ("binder: Split flat_binder_object") in kernel v4.11-rc1. Fix this by adding kernel version check at compile time.