### PR TITLE
policy: drop usage of files_list_pids()

### DIFF
--- a/policy/test_global.te
+++ b/policy/test_global.te
@@ -121,7 +121,6 @@ allow testsuite_domain proc_t:file { getattr read open };
 files_list_var(testsuite_domain)
 files_list_home(testsuite_domain)
 dev_read_rand(testsuite_domain)
-files_list_pids(testsuite_domain)
 require {
 	type root_t;
 	type etc_t;
@@ -153,6 +152,14 @@ selinux_compute_access_vector(testsuite_domain)
 selinux_compute_create_context(testsuite_domain)
 selinux_compute_relabel_context(testsuite_domain)
 selinux_compute_user_contexts(testsuite_domain)
+
+# Reference policy renamed files_list_pids() to files_list_runtime()
+ifdef(`files_list_pids', `
+    files_list_pids(testsuite_domain)
+')
+ifdef(`files_list_runtime', `
+    files_list_runtime(testsuite_domain)
+')
 
 ifdef(`distro_redhat', `
     ifdef(`auth_read_passwd', `


### PR DESCRIPTION
files_list_pids() has been superseded and marked deprecated in the Reference Policy since Jun 2020[1].  In the latest release it has been completely removed[2].

Grant the necessary permissions via raw rules to support recent Refpolicy versions as well as old ones without the replacement interface files_list_runtime().

[1]: https://github.com/SELinuxProject/refpolicy/commit/be04bb3e7e63671ed8a3c501a2ee76e11c3b92bb
[2]: https://github.com/SELinuxProject/refpolicy/commit/3ca0cd59d7a9b531dd3620a02940396343fe2ed5