### PR TITLE
ci: bump Fedora versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         domain: [unconfined_t, sysadm_t]
         env:
-          - { version: 36, kernel: default }
           - { version: 37, kernel: default }
-          - { version: 37, kernel: secnext }
+          - { version: 38, kernel: default }
+          - { version: 38, kernel: secnext }
     env:
       FEDORA_VERSION: ${{ matrix.env.version }}
       KERNEL_TYPE: ${{ matrix.env.kernel }}


### PR DESCRIPTION
Fedora 38 is the latest stable release, so update the Fedora versions we use for CI.