### PR TITLE
WIP: tests: Add cap2_userns checkpoint_restore test

### DIFF
--- a/policy/test_cap_userns.te
+++ b/policy/test_cap_userns.te
@@ -4,6 +4,7 @@
 #
 
 attribute capusernsdomain;
+attribute cap2usernsdomain;
 
 # Domain for process that is allowed non-init userns capabilities
 type test_cap_userns_t;
@@ -22,3 +23,17 @@ typeattribute test_no_cap_userns_t capusernsdomain;
 allow_userns_create(capusernsdomain)
 # linux >= v5.12 needs setfcap to map UID 0
 allow capusernsdomain self:capability setfcap;
+
+# Domain for process that is allowed to use cap_checkpoint_restore
+type test_cap2_userns_t;
+testsuite_domain_type(test_cap2_userns_t)
+typeattribute test_cap2_userns_t cap2usernsdomain;
+allow test_cap2_userns_t self:cap2_userns checkpoint_restore;
+
+# Domain for process that is not to use cap_checkpoint_restore
+type test_no_cap2_userns_t;
+testsuite_domain_type(test_no_cap2_userns_t)
+typeattribute test_no_cap2_userns_t cap2usernsdomain;
+
+# Rules common to both domains.
+kernel_rw_kernel_ns_lastpid_sysctl(cap2usernsdomain)

--- a/tests/cap_userns/test
+++ b/tests/cap_userns/test
@@ -11,7 +11,7 @@ BEGIN {
             "echo 1 > /proc/sys/kernel/unprivileged_userns_clone 2> /dev/null");
     }
     if ( system("$basedir/userns_child_exec -t -U > /dev/null 2>&1") == 0 ) {
-        plan tests => 2;
+        plan tests => 4;
     }
     else {
         plan skip_all => "CLONE_NEWUSER not supported";
@@ -29,6 +29,20 @@ ok( $result eq 0 );
 
 $result = system(
 "runcon -t test_no_cap_userns_t -- $basedir/userns_child_exec -p -m -U -M '0 0 1' -G '0 0 1' -- true 2>&1"
+);
+ok($result);
+
+# Verify that test_cap2_userns_t can use cap_checkpoint_restore
+
+$result = system(
+"$basedir/userns_child_exec -p -U -M '0 0 1' -G '0 0 1' -- runcon -t test_cap2_userns_t -- sysctl -w kernel.ns_last_pid=1000 2>&1"
+);
+ok( $result eq 0 );
+
+# Verify that test_no_cap_userns_t cannot use cap_checkpoint_restore
+
+$result = system(
+"$basedir/userns_child_exec -p -U -M '0 0 1' -G '0 0 1' -- runcon -t test_no_cap2_userns_t -- sysctl -w kernel.ns_last_pid=1000 2>&1"
 );
 ok($result);
 

--- a/tests/cap_userns/userns_child_exec.c
+++ b/tests/cap_userns/userns_child_exec.c
@@ -198,7 +198,7 @@ static char child_stack[STACK_SIZE];    /* Space for child's stack */
 int
 main(int argc, char *argv[])
 {
-	int flags, opt, map_zero, test_clone = 0;
+	int flags, opt, map_zero, test_clone = 0, wstatus;
 	pid_t child_pid;
 	struct child_args args;
 	char *uid_map, *gid_map;
@@ -332,11 +332,11 @@ main(int argc, char *argv[])
 
 	close(args.pipe_fd[1]);
 
-	if (waitpid(child_pid, NULL, 0) == -1)      /* Wait for child */
+	if (waitpid(child_pid, &wstatus, 0) == -1)      /* Wait for child */
 		errExit("waitpid");
 
 	if (verbose)
 		printf("%s: terminating\n", argv[0]);
 
-	exit(EXIT_SUCCESS);
+	exit(WEXITSTATUS(wstatus));
 }


### PR DESCRIPTION
Create a child process in new pid and user namespaces and drop CAP_SYS_ADMIN to enforce using CAP_CHECKPOINT_RESTORE capability which is required for writing to /proc/sys/kernel/ns_last_pid