### PR TITLE
Make sure to unmount filesystems before running rm -rf

### DIFF
--- a/tests/filesystem/Filesystem.pm
+++ b/tests/filesystem/Filesystem.pm
@@ -145,22 +145,28 @@ sub make_fs {
     }
 }
 
+sub umount_rm {
+    my ($path) = @_;
+    system("umount -R -l $path 2>/dev/null");
+    system("rm -rf $path 2>/dev/null");
+}
+
 sub mk_mntpoint_1 {
     my ($path) = @_;
-    system("rm -rf $path/mp1 2>/dev/null");
+    umount_rm("$path/mp1");
     system("mkdir -p $path/mp1 2>/dev/null");
 }
 
 sub mk_mntpoint_2 {
     my ($path) = @_;
-    system("rm -rf $path/mp2 2>/dev/null");
+    umount_rm("$path/mp2");
     system("mkdir -p $path/mp2 2>/dev/null");
 }
 
 sub cleanup {
     my ($base) = @_;
-    system("rm -rf $base/fstest 2>/dev/null");
-    system("rm -rf $base/mntpoint 2>/dev/null");
+    umount_rm("$base/fstest");
+    umount_rm("$base/mntpoint");
 }
 
 sub cleanup1 {
@@ -168,8 +174,8 @@ sub cleanup1 {
     system("udevadm settle");
     system("losetup -d $d 2>/dev/null");
     system("udevadm settle");
-    system("rm -rf $base/fstest 2>/dev/null");
-    system("rm -rf $base/mntpoint 2>/dev/null");
+    umount_rm("$base/fstest");
+    umount_rm("$base/mntpoint");
 }
 
 # Cleanup any attached /dev/loop entries


### PR DESCRIPTION
If one test fails in such a way that it doesn't clean up its mounts, this shouldn't be able to affect the results of future tests.